### PR TITLE
Suppressed performance warning for many small chunks in reorder(...)

### DIFF
--- a/stmtools/stm.py
+++ b/stmtools/stm.py
@@ -1,6 +1,7 @@
 """space-time matrix module."""
 
 import logging
+import warnings
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -9,7 +10,6 @@ import geopandas as gpd
 import numpy as np
 import pymorton as pm
 import xarray as xr
-import warnings
 from scipy.spatial import KDTree
 from shapely.geometry import Point
 from shapely.strtree import STRtree

--- a/stmtools/stm.py
+++ b/stmtools/stm.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import dask.array as da
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import pymorton as pm
 import xarray as xr
 import warnings

--- a/stmtools/stm.py
+++ b/stmtools/stm.py
@@ -422,7 +422,9 @@ class SpaceTimeMatrix:
                 "time": self._obj.chunksizes["time"][0],
             }
         with warnings.catch_warnings():
-            # Trying to supporess only [...]/lib/python3.12/site-packages/xarray/core/indexing.py:1620: PerformanceWarning: Slicing with an out-of-order index is generating [...] times more chunks
+            # Trying to supporess only
+            # [...]/lib/python3.12/site-packages/xarray/core/indexing.py:1620: PerformanceWarning:
+            # Slicing with an out-of-order index is generating [...] times more chunks
             # but unable to find the warning category.
             #warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
             warnings.simplefilter(action="ignore")

--- a/stmtools/stm.py
+++ b/stmtools/stm.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import dask.array as da
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pymorton as pm
 import xarray as xr
+import warnings
 from scipy.spatial import KDTree
 from shapely.geometry import Point
 from shapely.strtree import STRtree
@@ -392,6 +394,9 @@ class SpaceTimeMatrix:
         resolution of the ordering: only the whole-number part influences the order.
         While coordinates could also be offset, this has limited effect on the relative order.
 
+        Also note that reordering a dataset may be an expensive operation. Because it is applied
+        lazily, this preformance cost will only manifest once the elements are evaluated.
+
         Parameters
         ----------
         self : SpaceTimeMatrix
@@ -416,7 +421,12 @@ class SpaceTimeMatrix:
                 "space": self._obj.chunksizes["space"][0],
                 "time": self._obj.chunksizes["time"][0],
             }
-        self._obj = self._obj.sortby(self._obj.order)
+        with warnings.catch_warnings():
+            # Trying to supporess only [...]/lib/python3.12/site-packages/xarray/core/indexing.py:1620: PerformanceWarning: Slicing with an out-of-order index is generating [...] times more chunks
+            # but unable to find the warning category.
+            #warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
+            warnings.simplefilter(action="ignore")
+            self._obj = self._obj.sortby(self._obj.order)
         self._obj = self._obj.chunk(chunks)
 
         return self._obj


### PR DESCRIPTION
Resolves #73 

* Suppressed all warnings while calling xarray.sortby in stm.reorder.
* Added a note that only PerformanceWarning should be suppressed, but the type could not be properly determined.
* Indicated in reorder function description that this can be a costly operation.